### PR TITLE
Allow requests to have different val and key

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,7 +68,6 @@
   "dependencies": {
     "backbone": "^1.1.2",
     "backbone-metal-classify": "^1.0.1",
-    "backbone-normalize-hash": "^1.0.0",
     "backbone.radio": "^1.0.0",
     "es6-promise": "^2.1.1",
     "underscore": "^1.8.3"

--- a/src/backbone.service.js
+++ b/src/backbone.service.js
@@ -1,5 +1,4 @@
 import classify from 'backbone-metal-classify';
-import normalizeHash from 'backbone-normalize-hash';
 import Radio from 'backbone.radio';
 import _ from 'underscore';
 import PromisePolyfill from 'es6-promise';
@@ -17,11 +16,10 @@ export default Radio.Channel.extend({
    */
   constructor() {
     let start = _.once(() => resolved.then(() => this.start()));
-    let requests = normalizeHash(this, 'requests');
-
+    let requests = _.result(this, 'requests');
     _.each(requests, (val, key) => {
       this.reply(key, (...args) => {
-        let promise = start().then(() => this[key](...args));
+        let promise = start().then(() => this[val](...args));
 
         promise.catch(err => {
           this.onError(err);

--- a/test/unit/service.js
+++ b/test/unit/service.js
@@ -10,19 +10,25 @@ describe('Service', function() {
 
       requests: {
         foo: 'foo',
-        bar: 'bar',
+        bar: 'bar2',
       },
 
       foo: stub(),
-      bar: stub()
+      bar2: stub()
     });
 
     this.myService = new this.MyService();
   });
 
-  it('should bind requests', function() {
+  it('should bind requests where the key and value match', function() {
     return this.myService.request('foo').then(() => {
       expect(this.myService.foo).to.have.been.called;
+    });
+  });
+
+  it('should bind requests where the key and value don\'t match', function() {
+    return this.myService.request('bar').then(() => {
+      expect(this.myService.bar2).to.have.been.called;
     });
   });
 


### PR DESCRIPTION
I have noticed that `requests` require the `key` and `value` to match. This is due to this check (https://github.com/thejameskyle/backbone-normalize-hash/blob/master/index.js#L8), in this case `val` will never be a function, only a string.

I think using `_.result` should be sufficient to parse the `requests` hash in this case.
