### PR TITLE
Use backbone extend instead of classify

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,7 +67,6 @@
   },
   "dependencies": {
     "backbone": "^1.1.2",
-    "backbone-metal-classify": "^1.0.1",
     "backbone.radio": "^1.0.0",
     "es6-promise": "^2.1.1",
     "underscore": "^1.8.3"

--- a/src/backbone.service.js
+++ b/src/backbone.service.js
@@ -1,11 +1,39 @@
-import classify from 'backbone-metal-classify';
 import Radio from 'backbone.radio';
 import _ from 'underscore';
 import PromisePolyfill from 'es6-promise';
 
 const resolved = PromisePolyfill.Promise.resolve();
 
-Radio.Channel = classify(Radio.Channel);
+//copy of Backbone.js extend function
+Radio.Channel.extend = function(protoProps, staticProps) {
+  const parent = this;
+  let child;
+
+  // The constructor function for the new subclass is either defined by you
+  // (the "constructor" property in your `extend` definition), or defaulted
+  // by us to simply call the parent constructor.
+  if (protoProps && _.has(protoProps, 'constructor')) {
+    child = protoProps.constructor;
+  } else {
+    child = function() {
+      return parent.apply(this, arguments);
+    };
+  }
+
+  // Add static properties to the constructor function, if supplied.
+  _.extend(child, parent, staticProps);
+
+  // Set the prototype chain to inherit from `parent`, without calling
+  // `parent`'s constructor function and add the prototype properties.
+  child.prototype = _.create(parent.prototype, protoProps);
+  child.prototype.constructor = child;
+
+  // Set a convenience property in case the parent's prototype is needed
+  // later.
+  child.__super__ = parent.prototype;
+
+  return child;
+};
 
 /**
  * @class Service
@@ -29,7 +57,7 @@ export default Radio.Channel.extend({
       });
     });
 
-    this._super(...arguments);
+    Radio.Channel.prototype.constructor.apply(this, ...arguments);
   },
 
   /**


### PR DESCRIPTION
This PR just for reducing dependancies and reaching goal for using library without build tools. First step is removing `classify` dependancy. I just copy-pasted extend which Backbone.js uses (maybe not awesome idea in the world). So Service will be only depends on `_`, `Backbone`, `Radio` and `Promise` instead of `_`, `Backbone`, `Radio`, `Promise`, `Backbone-Metal`, `Backbone-Metal-Classify`... 
So it's 4 deps instead of 6 which is good.

This partly resolves #11 
